### PR TITLE
Fixed mislabeled alive or dead players in profiles page

### DIFF
--- a/static/html/profiles.html
+++ b/static/html/profiles.html
@@ -22,11 +22,11 @@
 				<td>{{ len(player.murders()) }}</td>
 				<td>{{ player.achievement_score() }}</td>
 				{% if player.death == None %}
-					<td>Dead</td>
-				{% else %}
 					<td>Alive</td>
+				{% else %}
+					<td>Dead</td>
 				{% end %}
-				<td>{{ " ".join(player.death.datetime.replace("T","+").split("+")[:2]) if player.death != None else None }}</tr>
+				<td>{{ " ".join(player.death.datetime.replace("T","+").split("+")[:2]) if player.death != None else "—" }}</tr>
 			</tr>
 		{% end %}
 		</tbody>


### PR DESCRIPTION
I found a bug in the profiles page where players that are dead are marked as being alive and vice versa. This is now rectified in the latest commit.