### PR TITLE
Fixed achievement updates when a murder is deleted

### DIFF
--- a/murder/achievement.py
+++ b/murder/achievement.py
@@ -86,7 +86,7 @@ class MurderAchievement(Achievement):
 			progress_record = AchievementProgress.find(achievement=self.id,player=player.id)
 			if progress_record == None:
 				AchievementProgress.add(achievement=self.id, player=player.id, progress=progress, completed=int(progress >= self.goal))
-			elif progress_record.completed != 1:
+			else:
 				progress_record.update(progress=progress, completed=int(progress >= self.goal))
 		
 	def condition(self, murder):
@@ -133,7 +133,7 @@ class ConsecutiveMurderAchievement(Achievement):
 			progress_record = AchievementProgress.find(achievement=self.id,player=player.id)
 			if progress_record == None:
 				AchievementProgress.add(achievement=self.id, player=player.id, progress=progress, completed=int(progress >= self.goal))
-			elif progress_record.completed != 1:
+			else:
 				progress_record.update(progress=progress, completed=int(progress >= self.goal))
 
 class DeathAchievement(Achievement):
@@ -150,7 +150,7 @@ class DeathAchievement(Achievement):
 			progress_record = AchievementProgress.find(achievement=self.id,player=player.id)
 			if progress_record == None:
 				AchievementProgress.add(achievement=self.id, player=player.id, progress=1 if death else 0, completed=1 if death else 0)
-			elif progress_record.completed != 1:
+			else:
 				progress_record.update(progress=1 if death else 0, completed=1 if death else 0)
 		
 	def condition(self, death):


### PR DESCRIPTION
Previously, the achievement progress will not be updated once it is completed in order to reduce the number of update query to the DB. With the addition of murder deletion, we need too update the achievement progress even when the achievement is completed (in case the removal of the murder cause the user to lose achievement). 

This issue can be seen in the screen shot below.

![screen shot 2015-01-05 at 1 00 14 pm](https://cloud.githubusercontent.com/assets/5274310/5608531/0f9344cc-94db-11e4-931f-28522602ef90.png)
